### PR TITLE
Reemplaze el lorem del breadcrumb por un slot customizable

### DIFF
--- a/src/components/layout/Breadcrumb.astro
+++ b/src/components/layout/Breadcrumb.astro
@@ -12,7 +12,7 @@
             <slot name="title">Title</slot>
           </h1>
           <p class="mb-5 text-base text-body-color dark:text-dark-6">
-            There are many variations of passages of Lorem Ipsum available.
+            <slot name="texto"></slot>
           </p>
 
           <ul class="flex items-center justify-center gap-[10px]">


### PR DESCRIPTION
El breadcrumb (que aparece al principio de las paginas y muestra el titulo y eso de Home/[titulo]) tenia un lorem debajo del titulo que no tenia sentido ya que si bien el titulo cambiaba según la pagina ese texto permanecería igual para todas.

Asi lo que lo cambie por un slot vacío para que si se lo requiere se lo puede modificar igual que se hace con el titulo.

Ej:
`<Breadcrumb> <Fragment slot="title">About Us Page</Fragment>
<Fragment slot="texto">Algún texto</Fragment> </Breadcrumb>`

(No se como separarlo en lineas al código sorry)