### PR TITLE
Modificados patrocinadores.

### DIFF
--- a/src/pages/participan/patrocinadores.astro
+++ b/src/pages/participan/patrocinadores.astro
@@ -114,7 +114,7 @@ const patrocinadores = [
         rrss: {
             "Instagram": "https://www.instagram.com/tecnica_taine/",
             "Tiktok": "https://www.tiktok.com/@tecnicataine",
-            "Twitter": "https://twitter.com/tecnicataine"
+            "Facebook": "https://www.facebook.com/tecnicataine"
         }
     },
     {


### PR DESCRIPTION
Se han modificado las redes sociales de Taine y se ha ocultado provisionalmente el patrocinio del Granada hasta aclararlo todo