### PR TITLE
Feature/159-Actualizar-Texto-En-El-Home

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -40,7 +40,7 @@ const orgs = [
     <p
       class="texto-centrado mx-auto mb-4 max-w-[600px] font-medium text-base text-white sm:text-lg sm:leading-[1.44]"
     >
-      ¡El mayor evento universitario de eSports de Granada!
+      ¡El mayor evento universitario de eSports de Andalucía!
     </p>
 
     <div class="flex items-center justify-center px-5 py-5 my-3">
@@ -84,13 +84,7 @@ const orgs = [
           </div>
         </div>
       </div>
-    </div>    
-
-    <p
-      class="texto-centrado mx-auto mb-4 max-w-[600px] font-medium text-base text-white sm:text-lg sm:leading-[1.44]"
-    >
-      ¡Nos volvemos a ver en 2025!
-    </p>
+    </div>
 
     <a
       href="/inscribete"


### PR DESCRIPTION
Cambiado el texto "¡El mayor evento universitario de eSports de Granada!" por "¡El mayor evento universitario de eSports de Andalucía!". Eliminado el texto "¡Nos volvemos a ver en 2025!"
![image](https://github.com/user-attachments/assets/e6e4e6cc-3902-4160-b026-a2d40590e784)
