### PR TITLE
#252 Arreglado - Modo claro incosistente en vista de móvil

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -66,13 +66,13 @@ const menuitems = [
             class="absolute right-4 top-1/2 block -translate-y-1/2 rounded-lg px-3 py-[6px] ring-primary focus:ring-2 lg:hidden"
           >
             <span
-              class="relative my-[6px] block h-[2px] w-[40px] bg-dark dark:bg-white"
+              class="relative my-[6px] block h-[2px] w-[40px] bg-white"
             ></span>
             <span
-              class="relative my-[6px] block h-[2px] w-[40px] bg-dark dark:bg-white"
+              class="relative my-[6px] block h-[2px] w-[40px] bg-white"
             ></span>
             <span
-              class="relative my-[6px] block h-[2px] w-[40px] bg-dark dark:bg-white"
+              class="relative my-[6px] block h-[2px] w-[40px] bg-white"
             ></span>
           </button>
           <nav


### PR DESCRIPTION
Arreglado el bug donde en la vista móvil del modo claro, los iconos del menú despegable mostraban los colores equivocados

<img width="153" height="264" alt="image" src="https://github.com/user-attachments/assets/eb78a816-8b9c-4f16-bf2b-62b1787a94fa" />
